### PR TITLE
Dup the VERSION string for Ruby 1.9 compatibility

### DIFF
--- a/api_smith.gemspec
+++ b/api_smith.gemspec
@@ -5,7 +5,7 @@ require 'api_smith/version'
 
 Gem::Specification.new do |s|
   s.name        = "api_smith"
-  s.version     = APISmith::VERSION
+  s.version     = APISmith::VERSION.dup
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Darcy Laycock", "Steve Webb"]
   s.email       = ["sutto@thefrontiergroup.com.au"]


### PR DESCRIPTION
Fails to install on Ruby 1.9

```
/Users/pranas/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:191:in `strip!': can't modify frozen String (RuntimeError)
    from /Users/pranas/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:191:in `initialize'
    from /Users/pranas/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:178:in `new'
    from /Users/pranas/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/site_ruby/1.9.1/rubygems/version.rb:178:in `create'
    from /Users/pranas/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/site_ruby/1.9.1/rubygems/specification.rb:2129:in `version='
    from /Users/pranas/Development/api_smith/api_smith.gemspec:8:in `block in <main>'
    from /Users/pranas/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/site_ruby/1.9.1/rubygems/specification.rb:1368:in `initialize'
    from /Users/pranas/Development/api_smith/api_smith.gemspec:6:in `new'
    from /Users/pranas/Development/api_smith/api_smith.gemspec:6:in `<main>'
```
