### PR TITLE
Allow to implement caching in instrumentation

### DIFF
--- a/lib/api_smith/client.rb
+++ b/lib/api_smith/client.rb
@@ -112,9 +112,8 @@ module APISmith
           request_options[type] = merged_options_for(type, options)
         end
         # Finally, use HTTParty to get the response
-        response = nil
-        instrument_request method, full_path, options do
-          response = self.class.send method, full_path, request_options
+        response = instrument_request method, full_path, options do
+          self.class.send method, full_path, request_options
         end
         # Pre-process the response to check for errors.
         check_response_errors response

--- a/spec/api_smith/client_spec.rb
+++ b/spec/api_smith/client_spec.rb
@@ -12,6 +12,20 @@ describe APISmith::Client do
 
   let(:client) { client_klass.new }
 
+  describe 'instrumentation' do
+    subject do
+      Class.new(client_klass) do
+        def instrument_request(*args)
+          'custom_response'
+        end
+      end.new
+    end
+
+    it 'should allow you to customize reponse' do
+      subject.get('/echo').should == 'custom_response'
+    end
+  end
+
   it 'should let you provide instrumentation' do
     second_klass = Class.new(client_klass) do
       attr_accessor :hits


### PR DESCRIPTION
I know this change breaks your API but it gives more power to `instrument_request` method. You can use it to implement caching for example.

Please consider this change.
