### PR TITLE
Updates to hashie 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     api_smith (1.2.0)
-      hashie (~> 1.0)
+      hashie (~> 2.0)
       httparty
 
 GEM
@@ -24,15 +24,15 @@ GEM
       thor (~> 0.14.6)
     guard-rspec (0.4.0)
       guard (>= 0.4.0)
-    hashie (1.2.0)
-    httparty (0.9.0)
+    hashie (2.0.5)
+    httparty (0.11.0)
       multi_json (~> 1.0)
-      multi_xml
+      multi_xml (>= 0.5.2)
     json (1.5.3)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
-    multi_json (1.3.6)
-    multi_xml (0.5.1)
+    multi_json (1.7.3)
+    multi_xml (0.5.3)
     rack (1.3.0)
     rake (0.8.7)
     rb-fsevent (0.9.1)

--- a/api_smith.gemspec
+++ b/api_smith.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency 'httparty'
-  s.add_dependency 'hashie',   '~> 1.0'
+  s.add_dependency 'hashie',   '~> 2.0'
 
   s.add_development_dependency 'rr'
   s.add_development_dependency 'rspec', '~> 2.0'


### PR DESCRIPTION
The long story:

It all started with the fact that I wanted to use `rocket_pants` in my rails 4.0 project and omniauth 2.0 depends on hashie 2.0, digging in rocket_pants turns out that he has a dependency on api_smith that depends on hashie 1.0
